### PR TITLE
Handle hashes in node['rbenv']['rubies']

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "rbenv_system_pkgs"
 maintainer       "Fletcher Nichol"
 maintainer_email "fnichol@nichol.ca"
 license          "Apache 2.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,6 +29,10 @@ rbenv_versions_path = "#{node['rbenv']['root_path']}/versions"
 rbenv_resource      = node['rbenv_system_pkgs']['rbenv_hook_resource']
 
 Array(node['rbenv']['rubies']).each do |ruby_version|
+  if ruby_version.is_a?(Hash)
+    ruby_version = ruby_version[:name]
+  end
+
   pkg_url = pkg_url_from_version(pkg_url_root, ruby_version)
 
   install_ruby_pkg_dependencies(ruby_version, rbenv_resource)


### PR DESCRIPTION
The chef-rbenv cookbook allows hashes in `node['rbenv']['rubies']` to
specify environment variables to be passed to ruby_build. With this,
rbenv_system_pkgs will extract the `name` element from such a hash to
use when looking for a pre-built package.
